### PR TITLE
remove unneeded bool_filter code

### DIFF
--- a/lib/estella/query.rb
+++ b/lib/estella/query.rb
@@ -109,17 +109,5 @@ module Estella
         end
       end
     end
-
-    def bool_filter(field, param)
-      if param
-        { term: { field => true } }
-      elsif !param.nil?
-        { term: { field => false } }
-      end
-    end
-
-    def add_bool_filter(field, param)
-      must bool_filter(field, param) if bool_filter(field, param)
-    end
   end
 end


### PR DESCRIPTION
This boolean filter code should actually live in Gravity as the more generic `add_filters` already handles boolean filters within the Estella context and is tested [here](https://github.com/artsy/estella/blob/master/spec/searchable_spec.rb#L77).

See artsy/gravity#10754
