### PR TITLE
Test against ElasticSearch 1.7.6 and 1.5.2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,7 @@ before_install:
   - curl -O $ELASTICSEARCH && sudo dpkg -i --force-confnew elasticsearch-*.deb
   - "echo 'script.inline: on' | sudo tee -a /etc/elasticsearch/elasticsearch.yml"
   - sudo /etc/init.d/elasticsearch start
-  - sleep 8
-  - curl -XGET http://localhost:9200
+  - until curl --silent -XGET --fail http://localhost:9200; do printf '.'; sleep 1; done
 
 rvm:
   - 2.2.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,22 @@ language: ruby
 
 cache: bundler
 
-rvm:
-  - 2.2.2
+before_script:
+  - bundle exec danger
+
+env:
+  - ELASTICSEARCH=https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.4.4/elasticsearch-2.4.4.deb
+  - ELASTICSEARCH=https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.1.1/elasticsearch-2.1.1.deb
+  - ELASTICSEARCH=https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.7.6.deb
+  - ELASTICSEARCH=https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.5.2.deb
 
 before_install:
   - gem update bundler
-  - "curl -O https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.1.1/elasticsearch-2.1.1.deb && sudo dpkg -i --force-confnew elasticsearch-2.1.1.deb"
+  - curl -O $ELASTICSEARCH && sudo dpkg -i --force-confnew elasticsearch-*.deb
   - "echo 'script.inline: on' | sudo tee -a /etc/elasticsearch/elasticsearch.yml"
-  - "sudo /etc/init.d/elasticsearch start"
-  - "sleep 5"
+  - sudo /etc/init.d/elasticsearch start
+  - sleep 8
+  - curl -XGET http://localhost:9200
 
-before_script:
-  - bundle exec danger
+rvm:
+  - 2.2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 0.3.1 (Next)
 
+* [#25](https://github.com/artsy/estella/pull/25): Support ElasticSearch 1.5.x - [@dblock](https://github.com/dblock).
 * [#21](https://github.com/artsy/estella/pull/21): Added Danger, PR linter - [@dblock](https://github.com/dblock).
 * [#20](https://github.com/artsy/estella/pull/20): Documented ES compatibility with 2.x - [@cavvia](https://github.com/cavvia).
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Builds on [elasticsearch-model](https://github.com/elastic/elasticsearch-rails/t
 
 ## Compatibility
 
-This library is compatible with [Elasticsearch 2.x](https://www.elastic.co/products/elasticsearch) and currently does not work with Elasticsearch 5.x (see [#18](https://github.com/artsy/estella/issues/18)). It works with many ORM/ODMs, including ActiveRecord and Mongoid.
+This library is compatible with [Elasticsearch 1.5.x, 2.x](https://www.elastic.co/products/elasticsearch) and currently does not work with Elasticsearch 5.x (see [#18](https://github.com/artsy/estella/issues/18)). It works with many ORM/ODMs, including ActiveRecord and Mongoid.
 
 ## Dependencies
 


### PR DESCRIPTION
Bonus: http://code.dblock.org/2017/02/10/installing-starting-and-waiting-for-elasticsearch-in-travis-ci.html