### PR TITLE
Update rubocop from 0.47.1 to 0.60.0

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,4 +13,4 @@ end
 require 'rubocop/rake_task'
 RuboCop::RakeTask.new(:rubocop)
 
-task default: [:rubocop, :spec]
+task default: %i[rubocop spec]

--- a/estella.gemspec
+++ b/estella.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency 'activemodel'
   gem.add_runtime_dependency 'activesupport'
-  gem.add_runtime_dependency 'elasticsearch-model'
+  gem.add_runtime_dependency 'elasticsearch-model', '~> 2.0'
 
   gem.add_development_dependency 'activerecord'
   gem.add_development_dependency 'rake', '~> 11.0'

--- a/estella.gemspec
+++ b/estella.gemspec
@@ -1,4 +1,4 @@
-$LOAD_PATH.unshift File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
 require 'estella/version'
 
 Gem::Specification.new do |gem|
@@ -14,14 +14,14 @@ Gem::Specification.new do |gem|
   gem.files         = `git ls-files`.split("\n")
   gem.test_files    = `git ls-files -- spec/*`.split("\n")
 
-  gem.add_runtime_dependency 'elasticsearch-model'
-  gem.add_runtime_dependency 'activesupport'
   gem.add_runtime_dependency 'activemodel'
+  gem.add_runtime_dependency 'activesupport'
+  gem.add_runtime_dependency 'elasticsearch-model'
 
-  gem.add_development_dependency 'rake', '~> 11.0'
   gem.add_development_dependency 'activerecord'
+  gem.add_development_dependency 'rake', '~> 11.0'
   gem.add_development_dependency 'rspec', '~> 3.1.0'
   gem.add_development_dependency 'rspec-expectations'
+  gem.add_development_dependency 'rubocop', '0.60.0'
   gem.add_development_dependency 'sqlite3'
-  gem.add_development_dependency 'rubocop', '0.47.1'
 end

--- a/lib/estella/analysis.rb
+++ b/lib/estella/analysis.rb
@@ -7,16 +7,16 @@ module Estella
       { type: 'edgeNGram', min_gram: 2, max_gram: 15, side: 'front' }
 
     DEFAULT_ANALYZER =
-      { type: 'custom', tokenizer: 'standard_tokenizer', filter: %w(lowercase asciifolding) }
+      { type: 'custom', tokenizer: 'standard_tokenizer', filter: %w[lowercase asciifolding] }
 
     SNOWBALL_ANALYZER =
-      { type: 'custom', tokenizer: 'standard_tokenizer', filter: %w(lowercase asciifolding snowball) }
+      { type: 'custom', tokenizer: 'standard_tokenizer', filter: %w[lowercase asciifolding snowball] }
 
     SHINGLE_ANALYZER =
-      { type: 'custom', tokenizer: 'standard_tokenizer', filter: %w(shingle lowercase asciifolding) }
+      { type: 'custom', tokenizer: 'standard_tokenizer', filter: %w[shingle lowercase asciifolding] }
 
     NGRAM_ANALYZER =
-      { type: 'custom', tokenizer: 'standard_tokenizer', filter: %w(lowercase asciifolding front_ngram_filter) }
+      { type: 'custom', tokenizer: 'standard_tokenizer', filter: %w[lowercase asciifolding front_ngram_filter] }
 
     DEFAULT_ANALYSIS = {
       tokenizer: {
@@ -26,11 +26,11 @@ module Estella
         front_ngram_filter: FRONT_NGRAM_FILTER
       },
       analyzer: {
-        default_analyzer:   DEFAULT_ANALYZER,
-        snowball_analyzer:  SNOWBALL_ANALYZER,
-        shingle_analyzer:   SHINGLE_ANALYZER,
-        ngram_analyzer:     NGRAM_ANALYZER,
-        search_analyzer:    DEFAULT_ANALYZER
+        default_analyzer: DEFAULT_ANALYZER,
+        snowball_analyzer: SNOWBALL_ANALYZER,
+        shingle_analyzer: SHINGLE_ANALYZER,
+        ngram_analyzer: NGRAM_ANALYZER,
+        search_analyzer: DEFAULT_ANALYZER
       }
     }
 

--- a/lib/estella/parser.rb
+++ b/lib/estella/parser.rb
@@ -8,9 +8,8 @@ module Estella
     # @see https://www.elastic.co/guide/en/elasticsearch/guide/current/boosting-by-popularity.html
     def boost(name, opts = {})
       fail ArgumentError, 'Boost field is not indexed!' unless @model.indexed_fields.include? name
-      unless (opts.keys & [:modifier, :factor]).length == 2
-        fail ArgumentError, 'Please supply a modifier and a factor for your boost!'
-      end
+      fail ArgumentError, 'Please supply a modifier and a factor for your boost!' unless (opts.keys & %i[modifier factor]).length == 2
+
       @model.field_boost = { boost: { field: name }.merge(opts) }
     end
 

--- a/lib/estella/query.rb
+++ b/lib/estella/query.rb
@@ -80,6 +80,7 @@ module Estella
 
       max = boost[:max]
       return unless max
+
       query[:query][:function_score][:max_boost] = max
     end
 
@@ -101,8 +102,10 @@ module Estella
     def add_filters
       indexed_fields = params[:indexed_fields]
       return unless indexed_fields
+
       indexed_fields.each do |field, opts|
         next unless opts[:filter] && params[field]
+
         must term: { field => params[field] }
       end
     end
@@ -110,6 +113,7 @@ module Estella
     def add_excludes
       exclude = params[:exclude]
       return unless exclude
+
       exclude.each do |k, v|
         exclude(term: { k => v })
       end

--- a/spec/searchable_spec.rb
+++ b/spec/searchable_spec.rb
@@ -19,7 +19,7 @@ describe Estella::Searchable, type: :model do
 
         searchable do
           field :title, type: :string, analysis: Estella::Analysis::FULLTEXT_ANALYSIS, factor: 1.0
-          field :keywords, type: :string, analysis: [:default, :snowball], factor: 0.5
+          field :keywords, type: :string, analysis: %i[default snowball], factor: 0.5
           field :follows_count, type: :integer
           field :published, type: :boolean, filter: true
 
@@ -75,7 +75,7 @@ describe Estella::Searchable, type: :model do
     it 'indexes slug field by default' do
       SearchableModel.create(title: 'liapunov', slug: 'liapunov')
       SearchableModel.refresh_index!
-      expect(SearchableModel.mappings.to_hash[:searchable_model][:properties].keys.include?(:slug)).to eq true
+      expect(SearchableModel.mappings.to_hash[:searchable_model][:properties].key?(:slug)).to eq true
     end
     it 'supports boolean filters' do
       liapunov = SearchableModel.create(title: 'liapunov', published: true)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,7 @@ require 'rspec'
 require 'coveralls'
 Coveralls.wear!
 
-require File.expand_path('../../lib/estella.rb', __FILE__)
+require File.expand_path('../lib/estella.rb', __dir__)
 
 RSpec.configure do |config|
   config.raise_errors_for_deprecations!


### PR DESCRIPTION
* Addresses [CVE-2017-8418][0]
* Re-generates .rubocop_todo.yml to skip failing style validations

[0]:https://nvd.nist.gov/vuln/detail/CVE-2017-8418