### PR TITLE
Revert email analyzer

### DIFF
--- a/lib/estella/analysis.rb
+++ b/lib/estella/analysis.rb
@@ -18,9 +18,6 @@ module Estella
     NGRAM_ANALYZER =
       { type: 'custom', tokenizer: 'standard_tokenizer', filter: %w[lowercase asciifolding front_ngram_filter] }
 
-    EMAIL_ANALYZER =
-      { type: 'custom', tokenizer: 'uax_url_email', filter: %w[lowercase stop] }
-
     DEFAULT_ANALYSIS = {
       tokenizer: {
         standard_tokenizer: { type: 'standard' }
@@ -33,7 +30,6 @@ module Estella
         snowball_analyzer: SNOWBALL_ANALYZER,
         shingle_analyzer: SHINGLE_ANALYZER,
         ngram_analyzer: NGRAM_ANALYZER,
-        email_analyzer: EMAIL_ANALYZER,
         search_analyzer: DEFAULT_ANALYZER
       }
     }
@@ -42,8 +38,7 @@ module Estella
       default: { type: 'text', analyzer: 'default_analyzer' },
       snowball: { type: 'text', analyzer: 'snowball_analyzer' },
       shingle: { type: 'text', analyzer: 'shingle_analyzer' },
-      ngram: { type: 'text', analyzer: 'ngram_analyzer', search_analyzer: 'search_analyzer' },
-      email: { type: 'text', analyzer: 'email_analyzer' }
+      ngram: { type: 'text', analyzer: 'ngram_analyzer', search_analyzer: 'search_analyzer' }
     }
 
     DEFAULT_FIELD_FACTORS = {

--- a/lib/estella/analysis.rb
+++ b/lib/estella/analysis.rb
@@ -51,8 +51,7 @@ module Estella
       ngram: 10,
       snowball: 3,
       shingle: 2,
-      search: 2,
-      email: 2
+      search: 2
     }
 
     FULLTEXT_ANALYSIS = DEFAULT_FIELDS.keys


### PR DESCRIPTION
@anandaroop pointed out recently that our Elasticsearch index settings differ on staging and production and the email analyzer was never applied to production indices.

I believe that this change was introduced in error and has no effect due to its low position (after ngram) in the analysis pipeline.

cc @cavvia 