### PR TITLE
release version 5.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Changelog
 
+### 5.0.1
+
+* [#33](https://github.com/artsy/estella/pull/32): Upgrade Rake to address [CVE-2020-8130](https://github.com/advisories/GHSA-jppv-gw3r-w3q8) - [@izakp](https://github.com/izakp).
+* [#32](https://github.com/artsy/estella/pull/32): Revert Email analyzer - [@izakp](https://github.com/izakp).
+
 ### 5.0.0
 
 * [#29](https://github.com/artsy/estella/pull/29): Support Elasticsearch 5.x - [@izakp](https://github.com/izakp).

--- a/estella.gemspec
+++ b/estella.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency 'activerecord'
   gem.add_development_dependency 'rake', '>= 12.3.3'
-  gem.add_development_dependency 'rspec', '~> 3.1.0'
+  gem.add_development_dependency 'rspec', '>= 3.5'
   gem.add_development_dependency 'rspec-expectations'
   gem.add_development_dependency 'rubocop', '0.60.0'
   gem.add_development_dependency 'sqlite3'

--- a/lib/estella/version.rb
+++ b/lib/estella/version.rb
@@ -1,3 +1,3 @@
 module Estella
-  VERSION = '5.0.0'
+  VERSION = '5.0.1'
 end


### PR DESCRIPTION
* [#33](https://github.com/artsy/estella/pull/33): Upgrade Rake to address [CVE-2020-8130](https://github.com/advisories/GHSA-jppv-gw3r-w3q8) - [@izakp](https://github.com/izakp).
* [#32](https://github.com/artsy/estella/pull/32): Revert Email analyzer - [@izakp](https://github.com/izakp).