### PR TITLE
compatibility with elasticsearch v7 (ONYX-842)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,9 @@ jobs:
   test:
     docker:
       - image: "cimg/ruby:<< parameters.ruby_version >>"
-      - image: elasticsearch:6.8.23
+      - image: docker.elastic.co/elasticsearch/elasticsearch:7.17.18
+        environment:
+          - discovery.type: single-node
     parameters:
       ruby_version:
         type: string
@@ -29,4 +31,4 @@ workflows:
       - test:
           matrix:
             parameters:
-              ruby_version: ["2.7"]
+              ruby_version: ["3.1"]

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Builds on [elasticsearch-model](https://github.com/elastic/elasticsearch-rails/t
 
 ## Compatibility
 
-This library is compatible with [Elasticsearch 1.5.x, 2.x](https://www.elastic.co/products/elasticsearch) when using versions `2.0.0` and earlier.  It is compatible with Elasticsearch 6.x via version `6.0.0` or installing directly from the `main` branch of this repository. It works with many ORM/ODMs, including ActiveRecord and Mongoid.
+This library is compatible with [Elasticsearch 1.5.x, 2.x](https://www.elastic.co/products/elasticsearch) when using versions `2.0.0` and earlier.  It is compatible with Elasticsearch 6.x via version `6.0.0`. It is compatible with Elasticsearch 7.x via version `7.0.0` or installing directly from the `main` branch of this repository. It works with many ORM/ODMs, including ActiveRecord and Mongoid.
 
 ## Dependencies
 

--- a/estella.gemspec
+++ b/estella.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency 'activemodel'
   gem.add_runtime_dependency 'activesupport'
-  gem.add_runtime_dependency 'elasticsearch-model', '~> 6.0'
+  gem.add_runtime_dependency 'elasticsearch-model', '~> 7.0'
 
   gem.add_development_dependency 'activerecord'
   gem.add_development_dependency 'pry'

--- a/lib/estella/helpers.rb
+++ b/lib/estella/helpers.rb
@@ -63,7 +63,7 @@ module Estella
 
       def bulk_index(batch_of_ids)
         create_index! unless index_exists?
-        __elasticsearch__.client.bulk index: index_name, type: document_type, body: batch_to_bulk(batch_of_ids)
+        __elasticsearch__.client.bulk index: index_name, body: batch_to_bulk(batch_of_ids)
       end
 
       # @return true if the index exists
@@ -98,7 +98,7 @@ module Estella
       end
 
       def es_delete_document(id)
-        __elasticsearch__.client.delete type: document_type, id: id, index: index_name
+        __elasticsearch__.client.delete id: id, index: index_name
       end
     end
   end

--- a/spec/searchable_spec.rb
+++ b/spec/searchable_spec.rb
@@ -20,8 +20,6 @@ describe Estella::Searchable, type: :model do
           'foo'
         end
 
-        document_type 'searchable_model'
-
         searchable do
           field :title, type: :text, analysis: Estella::Analysis::FULLTEXT_ANALYSIS, factor: 1.0
           field :keywords, type: :text, analysis: %i[default snowball], factor: 0.5
@@ -80,7 +78,7 @@ describe Estella::Searchable, type: :model do
     it 'indexes slug field by default' do
       SearchableModel.create(title: 'liapunov', slug: 'liapunov')
       SearchableModel.refresh_index!
-      expect(SearchableModel.mappings.to_hash[:searchable_model][:properties].key?(:slug)).to eq true
+      expect(SearchableModel.mappings.to_hash[:properties].key?(:slug)).to eq true
     end
     it 'supports boolean filters' do
       liapunov = SearchableModel.create(title: 'liapunov', published: true)


### PR DESCRIPTION
Work-in-progress to add elasticsearch v7 compatibility.

The major change is: https://www.elastic.co/guide/en/elasticsearch/reference/7.3/removal-of-types.html

This should probably become a v7 `estella` release in keeping with current practice. I've updated the README but will leave the gem version bump for a future commit.

This is just for review for now, as more changes may be necessary once clients test it more fully.