### PR TITLE
feat: searchable module index_slug supports FriendlyId

### DIFF
--- a/lib/estella/searchable.rb
+++ b/lib/estella/searchable.rb
@@ -57,10 +57,10 @@ module Estella
     end
 
     module ClassMethods
-      # support for mongoid::slug
+      # support for mongoid::slug and friendly_id (AR slugs)
       # indexes slug attribute by default
       def index_slug
-        if defined? slug
+        if method_defined?(:slug) || method_defined?(:friendly_id)
           indexed_fields.merge!(slug: { type: :keyword })
           indexed_json.merge!(slug: :slug)
         end


### PR DESCRIPTION
This PR relates to https://github.com/artsy/gravity/pull/18056

This adds support for indexing `slug` field (by default) for ActiveRecord based models. As suggested [here](https://github.com/artsy/gravity/pull/18056#discussion_r1745756568).

The primary change is an adjustment to logic to use `method_defined?` instead of `defined?` (which I am still confused about how it works). This should cover both ORM types by verifying that either `:slug` or `:friendly_id` methods are available and if they are, index the `slug` field.