### PR TITLE
chore: switch to a non deprecated ngram filter name

### DIFF
--- a/lib/estella/analysis.rb
+++ b/lib/estella/analysis.rb
@@ -6,7 +6,7 @@ module Estella
     extend ActiveSupport::Concern
 
     FRONT_NGRAM_FILTER =
-      { type: 'edgeNGram', min_gram: 2, max_gram: 15, side: 'front' }
+      { type: 'edge_ngram', min_gram: 2, max_gram: 15, side: 'front' }
 
     DEFAULT_ANALYZER =
       { type: 'custom', tokenizer: 'standard_tokenizer', filter: %w[lowercase asciifolding] }


### PR DESCRIPTION
Today I ran gravity specs and noticed a warning that was quite loud. To get rid of the warning this PR does what warning message says and updates the filter name to `edge_ngram`.

```sh
warning: 299 Elasticsearch-7.17.18-8682172c2130b9a411b1bd5ff37c9792367de6b0 "The [edgeNGram] token filter name is deprecated and will be removed in a future version. Please change the filter name to [edge_ngram] instead.
```

[Example in CI](https://app.circleci.com/pipelines/github/artsy/gravity/31380/workflows/1d350279-c07b-4618-8d4a-97fc3c5faf8d/jobs/60218?invite=true#step-105-50827_248)