### PR TITLE
feat: batch_to_bulk uses primary read mode for Mongoid models

### DIFF
--- a/lib/estella/helpers.rb
+++ b/lib/estella/helpers.rb
@@ -58,7 +58,13 @@ module Estella
       end
 
       def batch_to_bulk(batch_of_ids)
-        find(batch_of_ids).map(&:es_transform)
+        if defined?(Mongoid::Document) && ancestors.include?(Mongoid::Document)
+          with(read: :primary_preferred) do
+            find(batch_of_ids).map(&:es_transform)
+          end
+        else
+          find(batch_of_ids).map(&:es_transform)
+        end
       end
 
       def bulk_index(batch_of_ids)


### PR DESCRIPTION
When using `batch_to_bulk` on Mongoid models, read from primary.