### PR TITLE
fix: allow removing an index with alias

### DIFF
--- a/lib/estella/helpers.rb
+++ b/lib/estella/helpers.rb
@@ -72,7 +72,7 @@ module Estella
       end
 
       def delete_index!
-        __elasticsearch__.client.indices.delete index: index_name
+        __elasticsearch__.client.indices.delete index: provided_index_name
       end
 
       def create_index!
@@ -80,6 +80,10 @@ module Estella
                                                 body: {
                                                   settings: settings.to_hash, mappings: mappings.to_hash
                                                 }
+      end
+
+      def provided_index_name
+        __elasticsearch__.client.indices.get_settings(index: index_name).keys.first
       end
 
       def reload_index!


### PR DESCRIPTION
# Summary

Now we have an alias for indices on Gravity however, Elasticsearch client [doesn't allow deleting an index from an alias](https://github.com/elastic/elasticsearch-ruby/blob/a36796f0ddacc02a2134702c26cb10109f62c037/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete.rb#L33). To delete an index from an alias, we need to find the provided index name from an alias. 

Issue was reported here: https://artsy.slack.com/archives/C0HP61PUJ/p1754035490811419?thread_ts=1754034110.969649&cid=C0HP61PUJ