### PR TITLE
fix: add opensearch compatibility guardrails

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,11 +4,17 @@ jobs:
   test:
     docker:
       - image: "cimg/ruby:<< parameters.ruby_version >>"
-      - image: docker.elastic.co/elasticsearch/elasticsearch:7.17.18
+      - image: "<< parameters.search_image >>"
         environment:
           - discovery.type: single-node
+          # the following are ignored by elasticsearch images
+          - DISABLE_SECURITY_PLUGIN: "true"
+          - DISABLE_INSTALL_DEMO_CONFIG: "true"
+          - OPENSEARCH_JAVA_OPTS: "-Xms512m -Xmx512m"
     parameters:
       ruby_version:
+        type: string
+      search_image:
         type: string
     steps:
       - checkout
@@ -19,8 +25,8 @@ jobs:
           name: Print ruby version
           command: ruby -v
       - run:
-          name: Wait for ElasticSearch
-          command: dockerize -wait tcp://localhost:9200 -timeout 1m
+          name: Wait for search engine
+          command: dockerize -wait tcp://localhost:9200 -timeout 2m
       - run:
           name: Run test suite
           command: bundle exec rake
@@ -32,3 +38,6 @@ workflows:
           matrix:
             parameters:
               ruby_version: ["3.1"]
+              search_image:
+                - "docker.elastic.co/elasticsearch/elasticsearch:7.17.18"
+                - "opensearchproject/opensearch:3.3.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### v7.0.3 (Next)
 
+* [#51](https://github.com/artsy/estella/pull/51): fix: pin elasticsearch client below 7.14 for OpenSearch compatibility, fix test-only index settings applying in all environments, run CI against OpenSearch 2.x/3.x - [@egdbear]
 * Your contribution here.
 
 ### v7.0.2

--- a/estella.gemspec
+++ b/estella.gemspec
@@ -16,6 +16,8 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency 'activemodel'
   gem.add_runtime_dependency 'activesupport'
+  # elasticsearch 7.14+ refuses to connect to non-Elastic servers (e.g. OpenSearch)
+  gem.add_runtime_dependency 'elasticsearch', '>= 7.0', '< 7.14'
   gem.add_runtime_dependency 'elasticsearch-model', '~> 7.0'
 
   gem.add_development_dependency 'activerecord'

--- a/lib/estella/analysis.rb
+++ b/lib/estella/analysis.rb
@@ -53,7 +53,7 @@ module Estella
 
     FULLTEXT_ANALYSIS = DEFAULT_FIELDS.keys
 
-    DEFAULT_SETTINGS = if defined? Rails && Rails.env == 'test'
+    DEFAULT_SETTINGS = if defined?(Rails) && Rails.env == 'test'
                          # Ensure no sharding in test env in order to enforce deterministic scores.
                          { analysis: DEFAULT_ANALYSIS, index: { number_of_shards: 1, number_of_replicas: 1 } }
                        else


### PR DESCRIPTION
## Description

Our OpenSearch cluster is now on v3, but estella's compatibility with it depends entirely on consuming apps pinning the right client version themselves. Three changes to lock in what production already relies on:

1. **Pin the transitive `elasticsearch` client to `< 7.14`** in the gemspec. Clients 7.14+ run a product check that refuses to connect to OpenSearch ([elastic/elasticsearch-ruby#1429](https://github.com/elastic/elasticsearch-ruby/issues/1429)). Gravity already carries this pin in its own Gemfile; this moves it upstream so no consumer can resolve a broken client via `bundle update` or a missing pin. With it, bundler locks `elasticsearch 7.13.3` alongside `elasticsearch-model 7.2.1`.

2. **Fix an operator-precedence bug in `DEFAULT_SETTINGS`** (`lib/estella/analysis.rb`). `defined? Rails && Rails.env == 'test'` parses as `defined?((Rails && ...))`, which is always truthy, even when Rails isn't loaded. The "test-only" `number_of_shards: 1, number_of_replicas: 1` settings were therefore applied in every environment, including production. Now they only apply in a Rails test env.

3. **Run CI against OpenSearch.** The test now covers Elasticsearch 7.17.18 (unchanged), OpenSearch 2.19.1, and OpenSearch 3.3.0 (our live), so CI tests against what production actually runs. If a future OpenSearch version breaks the pinned client, the build goes red instead of production.

## Context

OpenSearch 3 removed `compatibility.override_main_response_version` ([opensearch#18228](https://github.com/opensearch-project/OpenSearch/issues/18228)), so there is no server-side compatibility fallback anymore: everything rests on the client staying below 7.14. That client (7.13.3) is end-of-life, which is fine as a stopgap but not a destination.

Note: the two OpenSearch CI jobs are new, so this PR's build is the first real evidence of whether the suite passes against 2.x and 3.x.

## Heads-up for consumers

The settings fix changes behavior for models calling bare `searchable do ... end` without explicit settings outside of tests: new indices get cluster defaults instead of a forced 1 shard / 1 replica. OpenSearch defaults are also 1/1, so nothing changes in practice unless cluster-level index templates say otherwise. In Gravity, all searchable models pass explicit settings except `Video`, which deserves a small follow-up.

## Next steps: estella 8.0 on opensearch-ruby or different approach TBD

Slack context [here](https://artsy.slack.com/archives/CA8SANW3W/p1762244299565049). 

The real fix is dropping `elasticsearch-model` and `elasticsearch` entirely and rebuilding estella's thin integration layer on `opensearch-ruby`, released as estella 8.0. The surface estella actually uses from `elasticsearch-model` is small: `index_name` storage, the `settings`/`mapping` capture, `import`, the client proxy, and the hits-to-records loader. That's a few hundred lines to reimplement.

Gravity already has `opensearch-ruby` 3.4.0 for its recommendation and duplicate-detection services, so 8.0 would consolidate two client stacks into one that's already proven in production. It's also the right moment to add alias support (create-with-alias, swap-based reindexing): Gravity's indices are now aliased on the cluster, which breaks `reload_index!` — see #48 for an earlier attempt at a partial fix. Since the index lifecycle methods get rewritten in 8.0 anyway, that's where the complete fix belongs.
